### PR TITLE
Solución al bug para descargar etiquetas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,17 @@ export class Andreani {
     return Buffer.from(`${this.USER}:${this.PASS}`).toString("base64");
   }
 
-  private async getReq(url: string) {
-    return await axios.get(url, this.configAuth).then((x) => x.data);
+  private async getReq(url: string, binary: boolean = false) {
+
+    const binaryConfigAuth = () => {
+      let result = this.configAuth;
+      const cfg = {...result, responseType: 'arraybuffer'};
+      return cfg;
+    }
+          
+    const auth = binary ? binaryConfigAuth() : this.configAuth;
+
+    return await axios.get(url, auth).then((x) => x.data);
   }
 
   private async postReq(url: string, body: any) {
@@ -127,7 +136,7 @@ export class Andreani {
   }
 
   private async $obtenerEtiqueta(remito: string) {
-    return await this.getReq(this.OBT_ETQ_URL(remito));
+    return await this.getReq(this.OBT_ETQ_URL(remito), true);
   }
 
   async cotizarEnvioSucursal(params: PedidoCotizacion): Promise<Cotizacion> {


### PR DESCRIPTION
Al intentar descargar las etiquetas de un envío el PDF llegaba corrupto por como Axios hacía el request. La solución que implementé es agregar un parámetro adiciona la la función `getReq `para indicar que el elemento que se quiere obtener es un binario. En base a ese flag la función modifica los parámetros de axios para manejar el caso. El parámetro adicionado es opcional seteado en false, por lo que no afecta al resto de las funciones. Luego, el método` $obtenerEtiqueta` llama a `getReq `pasando true como segundo parámetro.